### PR TITLE
Add option to override sign-addon default timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You can use the following extra options:
 * `apiKey`: The API key used for signing
 * `apiSecret`: The API secret used for signing
 * `apiUrlPrefix`: The URL of the signing API, defaults to AMO production
+* `timeout`: The number of milliseconds to wait before giving up on a response from Mozilla's web service. Defaults to 900000 ms (15 minutes).
 
 Changing apiUrlPrefix will allow you to submit to addons.thunderbird.net or using the staging/dev instance.
 
@@ -131,6 +132,7 @@ jobs:
           channel: unlisted
           apiKey: ${{ secrets.AMO_SIGN_KEY }}
           apiSecret: ${{ secrets.AMO_SIGN_SECRET }}
+          timeout: 900000
 
       - name: "Create Release"
         uses: softprops/action-gh-release@v1

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,12 @@ inputs:
     description: "[sign] The URL of the signing API, defaults to AMO production"
     required: false
     default: "https://addons.mozilla.org/api/v3"
+  timeout:
+    description: |
+      [sign] The number of milliseconds to wait before giving up on a response
+      from Mozilla's web service. Defaults to 900000 ms (15 minutes).
+    required: false
+    default: 900000
 runs:
   using: "node12"
   main: "src/loader.js"

--- a/src/action.js
+++ b/src/action.js
@@ -148,6 +148,7 @@ export default class WebExtAction {
         apiKey: this.options.apiKey,
         apiSecret: this.options.apiSecret,
         apiUrlPrefix: this.options.apiUrlPrefix,
+        timeout: this.options.timeout,
         verbose: this.options.verbose
       });
     } catch (e) {

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ async function main() {
     apiKey: mask(core.getInput("apiKey")),
     apiSecret: mask(core.getInput("apiSecret")),
     apiUrlPrefix: core.getInput("apiUrlPrefix"),
+    timeout: core.getInput("timeout"),
   });
 
 


### PR DESCRIPTION
The sign-addon default timeout is supposed to be 15 minutes. In practice users may want to change this timeout value. Previously there was no way to do so from this action even though it's a parameter to sign-addon itself. This change set just exposes the option to override the timeout and passes it along when calling sign-addon's main function.

@kewisch I went ahead and prepared this to resolve #9. Let me know if there's a different direction this should take or if you already have your own implementation. Happy to take suggestions or let you edit this as you see fit.