### PR TITLE
Fall back to yaml if web extension id not in manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You can use the following extra options:
 * `apiKey`: The API key used for signing
 * `apiSecret`: The API secret used for signing
 * `apiUrlPrefix`: The URL of the signing API, defaults to AMO production
+* `geckoId`: The web extension id, can also be specified in the manifest under browser_specific_settings.gecko.id or applications.gecko.id.
 * `timeout`: The number of milliseconds to wait before giving up on a response from Mozilla's web service. Defaults to 900000 ms (15 minutes).
 
 Changing apiUrlPrefix will allow you to submit to addons.thunderbird.net or using the staging/dev instance.
@@ -132,6 +133,7 @@ jobs:
           channel: unlisted
           apiKey: ${{ secrets.AMO_SIGN_KEY }}
           apiSecret: ${{ secrets.AMO_SIGN_SECRET }}
+          geckoId: ${{ secrets.AMO_GECKO_ID }}
           timeout: 900000
 
       - name: "Create Release"

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
     description: "[sign] The URL of the signing API, defaults to AMO production"
     required: false
     default: "https://addons.mozilla.org/api/v3"
+  geckoId:
+    description: "[sign] The web extension/gecko id used for signing"
+    required: false
   timeout:
     description: |
       [sign] The number of milliseconds to wait before giving up on a response

--- a/src/action.js
+++ b/src/action.js
@@ -131,7 +131,11 @@ export default class WebExtAction {
       try {
         id = manifest.applications.gecko.id;
       } catch (err) {
-        throw new Error("Must specify an add-on id in the manifest at browser_specific_settings.gecko.id");
+        try {
+          id = this.options.geckoId;
+        } catch (error) {
+          throw new Error("Must specify an add-on id in the manifest at browser_specific_settings.gecko.id or geckoId in action yaml");
+        }
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ async function main() {
     apiKey: mask(core.getInput("apiKey")),
     apiSecret: mask(core.getInput("apiSecret")),
     apiUrlPrefix: core.getInput("apiUrlPrefix"),
+    geckoId: core.getInput("geckoId"),
     timeout: core.getInput("timeout"),
   });
 


### PR DESCRIPTION
This avoids a conflict with manifest.json for chrome extensions by adding a key geckoId as fallback if browser_specific_settings.gecko.id and applications.gecko.id are missing in manifest.json.