### PR TITLE
Introduce cusomization of the extension's filename in the artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ build
 
 A simple web-ext build. Folders `.git`, `.github` and `web-ext-artifacts` are automatically ignored. You can use the `target` output for subsequent steps.
 
+You can use the following extra options:
+* `filename`: Template string for the packed extension's filename, available for download through the job's artifacts. The placeholders in braces (`{...}`) are replaced by the corresponding entries in the extension's `manifest.json`. E.g. `"{name}-{version}.xpi"`.
+
 ```yaml
 name: "Build"
 on:
@@ -75,6 +78,7 @@ jobs:
         with:
           cmd: build
           source: src
+          filename: "{name}-{version}.xpi"
 
       - name: "Upload Artifact"
         uses: actions/upload-artifact@master

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
       from Mozilla's web service. Defaults to 900000 ms (15 minutes).
     required: false
     default: 900000
+  filename:
+    description: "Filename template for the packed extension in the artifacts"
+    required: false
 runs:
   using: "node12"
   main: "src/loader.js"

--- a/src/action.js
+++ b/src/action.js
@@ -109,6 +109,8 @@ export default class WebExtAction {
     let results = await webExt.cmd.build({
       sourceDir: this.options.sourceDir,
       artifactsDir: this.options.artifactsDir,
+      filename: this.options.extensionFilenameTemplate ?
+        this.options.extensionFilenameTemplate : undefined,
       overwriteDest: true,
       ignoreFiles: [".git", ".github", "web-ext-artifacts"],
     }, {

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ async function main() {
     channel: core.getInput("channel"),
     verbose: core.getInput("verbose") == "true",
 
+    // Build options
+    extensionFilenameTemplate: core.getInput("filename"),
+
     // Linting options
     token: process.env.GITHUB_TOKEN,
 


### PR DESCRIPTION
I was annoyed that using the pipeline for my extension led to ZZZ.zip files. However, prior to installing or deploying my extension I manually renamed it to ZZZ.xpi anyway. So I thought, let's offer the action some customization option to choose the full filename as an optional parameter.