### PR TITLE
Add ignoreFiles as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Generally you can use these inputs:
 * `verbose`: Output more debugging if set to true
 * `progressBar`: Enable the console progress bar
 * `channel`: The channel to use, `listed` or `unlisted`
+* `ignoreFiles`: A json string containing an array of files to be ignored. Web-ext by default already ignores the most frequently ignored files.
 
 There are a few more specific to each command.
 
 lint
 ----
 
-Linting supports annotations, this is great for pull requests. Folders `.git`, `.github` and
-`web-ext-artifacts` are automatically ignored. A token is not required for this action, though if
+Linting supports annotations, this is great for pull requests. A token is not required for this action, though if
 `GITHUB_TOKEN` is in the environment, it will be used to create a check run.
 
 ```yaml
@@ -51,7 +51,7 @@ jobs:
 build
 -----
 
-A simple web-ext build. Folders `.git`, `.github` and `web-ext-artifacts` are automatically ignored.
+A simple web-ext build.
 You can use the `target` output for subsequent steps.
 
 You can use the following extra options:
@@ -80,6 +80,7 @@ jobs:
           cmd: build
           source: src
           filename: "{name}-{version}.xpi"
+          ignoreFiles: '[ "package.json","package-lock.json","yarn.lock" ]'
 
       - name: "Upload Artifact"
         uses: actions/upload-artifact@master

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Show the progress bar in command output"
     required: false
     default: false
+  ignoreFiles:
+    description: "JSON array with files to ignore"
+    required: false
+    default: "[]"
   channel:
     description: "[lint+sign] The target channel"
     required: false

--- a/src/action.js
+++ b/src/action.js
@@ -89,7 +89,7 @@ export default class WebExtAction {
       artifactsDir: this.options.artifactsDir,
       selfHosted: this.options.channel == "unlisted",
       output: this.options.verbose ? "text" : "none",
-      ignoreFiles: [".git", ".github", "web-ext-artifacts"],
+      ignoreFiles: JSON.parse(this.options.ignoreFiles),
     }, {
       shouldExitProgram: false
     });
@@ -118,7 +118,7 @@ export default class WebExtAction {
       filename: this.options.extensionFilenameTemplate ?
         this.options.extensionFilenameTemplate : undefined,
       overwriteDest: true,
-      ignoreFiles: [".git", ".github", "web-ext-artifacts"],
+      ignoreFiles: JSON.parse(this.options.ignoreFiles),
     }, {
       showReadyMessage: false,
       shouldExitProgram: false
@@ -158,7 +158,8 @@ export default class WebExtAction {
         apiUrlPrefix: this.options.apiUrlPrefix,
         timeout: this.options.timeout,
         verbose: this.options.verbose,
-        disableProgressBar: !this.options.progressBar
+        disableProgressBar: !this.options.progressBar,
+        ignoreFiles: JSON.parse(this.options.ignoreFiles)
       });
     } catch (e) {
       if (

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ async function main() {
     artifactsDir: core.getInput("artifacts"),
     channel: core.getInput("channel"),
     verbose: core.getInput("verbose") == "true",
+    ignoreFiles: core.getInput("ignoreFiles"),
 
     // Build options
     extensionFilenameTemplate: core.getInput("filename"),


### PR DESCRIPTION
Use the list of files to ignore from argument, not from redundant default list.

By default, web-ext already ignores (from src/util/file-filter.js):
```
    [
      '**/*.xpi',
      '**/*.zip',
      '**/.*', // any hidden file and folder
      '**/.*/**/*', // and the content inside hidden folder
      '**/node_modules',
      '**/node_modules/**/*',
    ]
+ artifactsDir
+ ignoreFiles
```