### PR TITLE
Add verbose option to build command

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -108,6 +108,9 @@ export default class WebExtAction {
   }
 
   async cmd_build() {
+    if (this.options.verbose) {
+      webExt.util.logger.consoleStream.makeVerbose();
+    }
     let results = await webExt.cmd.build({
       sourceDir: this.options.sourceDir,
       artifactsDir: this.options.artifactsDir,


### PR DESCRIPTION
Use the verbose argument to execute the web-ext build as the --verbose option was given on the command line.