### PR TITLE
update KNOWN_LICENSE

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 ---
-name: web-ext Action for Firefox Add-ons
-author: Philipp Kewisch <mozilla@kewis.ch>
+name: "web-ext Action for Firefox Add-ons (phuwit's fork)"
+author: Phuwit Puthipairoj <26784267+phuwit@users.noreply.github.com>
 description: Run a web-ext commmand
 branding:
   icon: box

--- a/src/action.js
+++ b/src/action.js
@@ -16,10 +16,9 @@ import * as github from "@actions/github";
 import * as core from "@actions/core";
 
 const KNOWN_LICENSES = new Set([
-  "all-rights-reserved", "MPL-2.0", "GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.1-or-later",
-  "LGPL-3.0-or-later", "MIT", "BSD-2-Clause"
+  "all-rights-reserved", "MPL-2.0", "Apache-2.0", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only",
+  "LGPL-3.0-only", "AGPL-3.0-only", "MIT", "ISC", "BSD-2-Clause", "Unlicense"
 ]);
-
 async function getManifest(xpi) {
   try {
     let data = await fs.promises.readFile(xpi);


### PR DESCRIPTION
I've accessed https://mozilla.github.io/addons-server/topics/api/licenses.html#license-list on 09/12/2024 and the known license list on the mozilla docs mismatched on the actions source code.