### PR TITLE
feat: add separate approvalTimeout for AMOv5

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,12 @@ You can use the following extra options:
 * `apiKey`: The API key used for signing.
 * `apiSecret`: The API secret used for signing.
 * `apiUrlPrefix`: The URL of the signing API, defaults to AMO production.
-* `timeout`: The number of milliseconds to wait before giving up on a response from Mozilla's web
-   service. Defaults to 900000 ms (15 minutes).
+* `timeout`: The number of milliseconds to wait for upload and validation to complete before
+   giving up. Defaults to 900000 ms (15 minutes).
+* `approvalTimeout`: The number of milliseconds to wait for AMO to approve the submission and
+   return the signed XPI. Set to `0` to skip waiting entirely: the action succeeds as soon as
+   upload and validation succeed, and no signed XPI is downloaded (the `target` and `name`
+   outputs will be `null`). AMO API v5 only.
 
 Changing `apiUrlPrefix` to https://addons.thunderbird.net/api/v4 will allow you to submit to
 [addons.thunderbird.net](https://addons.thunderbird.net), or you can make use of the

--- a/action.yml
+++ b/action.yml
@@ -73,10 +73,18 @@ inputs:
     default: https://addons.mozilla.org/api/v5
   timeout:
     description: |
-      [sign] The number of milliseconds to wait before giving up on a response from Mozilla's web
-      service. Defaults to 900000 ms (15 minutes).
+      [sign] The number of milliseconds to wait for upload and validation to complete before
+      giving up. Also used as the default for `approvalTimeout` when it is not set.
+      Defaults to 900000 ms (15 minutes).
     required: false
     default: 900000
+  approvalTimeout:
+    description: |
+      [sign] The number of milliseconds to wait for AMO to approve the submission and return
+      the signed XPI. Set to 0 to skip waiting entirely: the action succeeds as soon as
+      upload and validation succeed, and no signed XPI is downloaded (the `target` and
+      `name` outputs will be null). When unset, falls back to `timeout`. AMO API v5 only.
+    required: false
 runs:
   using: node20
   main: src/index.js

--- a/src/action.js
+++ b/src/action.js
@@ -190,12 +190,20 @@ export default class WebExtAction {
     let uploadUuid;
     try {
       if (this.options.apiUrlPrefix.includes("v5")) {
+        // `approvalTimeout` (milliseconds) falls back to `timeout` when unset. A value of 0
+        // disables waiting for AMO approval and skips downloading the signed XPI; see the
+        // success branch below for the corresponding result handling.
+        let approvalCheckTimeout = this.options.timeout;
+        if (this.options.approvalTimeout !== "" && this.options.approvalTimeout != null) {
+          approvalCheckTimeout = Number(this.options.approvalTimeout);
+        }
+
         result = await signAddonV5({
           apiKey: this.options.apiKey,
           apiSecret: this.options.apiSecret,
           amoBaseUrl: this.options.apiUrlPrefix,
           validationCheckTimeout: this.options.timeout,
-          approvalCheckTimeout: this.options.timeout,
+          approvalCheckTimeout: approvalCheckTimeout,
           id: id,
           xpiPath: this.options.sourceDir,
           downloadDir: this.options.artifactsDir,
@@ -268,6 +276,19 @@ export default class WebExtAction {
       };
     } else if (result.errorCode == "ADDON_NOT_AUTO_SIGNED") {
       core.warning("The add-on passed validation, but was not auto-signed (listed, or held for manual review)");
+      return {
+        addon_id: result.id,
+        target: null,
+        name: null,
+        upload: uploadUuid?.uploadUuid,
+        channel: uploadUuid?.channel,
+        crcHash: uploadUuid?.xpiCrcHash
+      };
+    } else if (Number(this.options.approvalTimeout) === 0 && !result.errorCode) {
+      // approvalTimeout=0 tells web-ext's signAddon to return as soon as upload and
+      // validation succeed, without polling for approval or downloading a signed XPI.
+      // The result carries an id but no downloadedFiles and no errorCode; treat as success.
+      core.info("Submitted to AMO. Skipped waiting for approval and signed XPI (approvalTimeout=0).");
       return {
         addon_id: result.id,
         target: null,

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ async function main() {
     apiSecret: mask(core.getInput("apiSecret")),
     apiUrlPrefix: core.getInput("apiUrlPrefix"),
     timeout: core.getInput("timeout"),
+    approvalTimeout: core.getInput("approvalTimeout"),
   });
 
 


### PR DESCRIPTION
The current action always waits for AMOv5 approval and the resulting signed XPI (both driven by the single `timeout` input, which caps at 15 min and requires the job to stay alive that long). For CI pipelines that just need to submit a version reliably on release and **don't** need the signed artifact back in the same job, the wait forces either a doomed timeout or an artificially high `timeout` that ties up a runner.

`web-ext`'s `signAddon` already supports decoupling these via `approvalCheckTimeout: 0` (see [`mozilla/web-ext` `lib/util/submit-addon.js`](https://github.com/mozilla/web-ext/blob/db7c12c653254b69182f9dbea2c55c6beeddacaf/src/util/submit-addon.js#L262-L268). This PR surfaces that as a new `approvalTimeout` input in the `action-web-ext`.

- Defaults to current behavior (falls back to `timeout` when unset), so existing workflows are unaffected.
- `approvalTimeout: 0` -> action succeeds as soon as upload & validation succeed; no signed file is downloaded. Outputs `target: null` and `name: null` in that case.
- Scoped to the v5 code path. v4 doesn't expose a separate approval timeout and is untouched.
- Adds a handler for the "submitted, not waiting" result shape so the action reports success instead of falling through to the generic failure branch.

**Testing:** Used my forked build in a [real release pipeline of my own](https://github.com/Texarkanine/tab-yeet/actions/runs/24580330628/job/71876309360#step:5:16). Submission succeeds, job terminates with success w/out waiting for a signed XPI.